### PR TITLE
fix: correct sales-agent API usage and webhook docs

### DIFF
--- a/sales-agent/README.md
+++ b/sales-agent/README.md
@@ -59,7 +59,8 @@ curl -X POST https://api.agentmail.to/v0/webhooks \
      -H "Authorization: Bearer $AGENTMAIL_API_KEY" \
      -H "Content-Type: application/json" \
      -d "{
-  \"url\": \"https://$WEBHOOK_DOMAIN/webhooks\"
+  \"url\": \"https://$WEBHOOK_DOMAIN/webhooks\",
+  \"event_types\": [\"message_received\"]
 }"
 ```
 

--- a/sales-agent/main.py
+++ b/sales-agent/main.py
@@ -66,7 +66,7 @@ Body:\n{email["text"]}
     response = asyncio.run(Runner.run(agent, messages + [{"role": "user", "content": prompt}]))
     print("Response:\n\n", response.final_output, "\n")
 
-    client.messages.reply(inbox_id=inbox, message_id=email["message_id"], text=response.final_output)
+    client.inboxes.messages.reply(inbox_id=inbox, message_id=email["message_id"], text=response.final_output)
 
     messages = response.to_input_list()
 


### PR DESCRIPTION
Fix client.messages.reply to client.inboxes.messages.reply in main.py (fixes #4). Add required event_types field to webhook creation curl in README (fixes #3).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sales-agent example to use the correct reply API and updates webhook docs to include the required event_types field.

- **Bug Fixes**
  - Use client.inboxes.messages.reply in main.py so replies send correctly.
  - Add event_types: ["message_received"] to the webhook curl in README to prevent API errors.

<sup>Written for commit cbad985d0e51cc761631e5af192b38acda048808. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

