### PR TITLE
fix: correct email-agent API usage and webhook docs

### DIFF
--- a/email-agent/README.md
+++ b/email-agent/README.md
@@ -59,7 +59,8 @@ curl -X POST https://api.agentmail.to/v0/webhooks \
      -H "Authorization: Bearer $AGENTMAIL_API_KEY" \
      -H "Content-Type: application/json" \
      -d "{
-  \"url\": \"https://$WEBHOOK_DOMAIN/webhooks\"
+  \"url\": \"https://$WEBHOOK_DOMAIN/webhooks\",
+  \"event_types\": [\"message_received\"]
 }"
 ```
 

--- a/email-agent/main.py
+++ b/email-agent/main.py
@@ -49,7 +49,7 @@ Body:\n{email["text"]}
     response = asyncio.run(Runner.run(agent, prompt))
     print("Response:\n\n", response.final_output, "\n")
 
-    client.messages.reply(inbox_id=inbox, message_id=email["message_id"], text=response.final_output)
+    client.inboxes.messages.reply(inbox_id=inbox, message_id=email["message_id"], text=response.final_output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Fix `client.messages.reply()` → `client.inboxes.messages.reply()` in email-agent (same bug as #4 in sales-agent)
- Add missing `event_types` field to webhook creation curl command in email-agent README (same bug as #3 in sales-agent)

These are the same two bugs fixed in #9 for the sales-agent, now also fixed in the email-agent.

## Test plan
- [x] Verified the correct API matches `dinner-agent` and `github-maintainer-agent` which already use `client.inboxes.messages.reply()`
- [x] Verified webhook creation requires `event_types` per AgentMail API docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected the email-agent reply call to use client.inboxes.messages.reply and updated the webhook example to include event_types. This prevents reply failures and ensures webhooks can be created successfully with AgentMail.

<sup>Written for commit 798fa0b802c8c33148be47cebcb8c0af0f7f0e68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

